### PR TITLE
feat: add hex encoding support for passwords and UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ By default - when using the [Helm chart](https://github.com/sap/secret-generator
 Then, secret values of the form `%generate:<type>[:<arg=value>;<arg=value>;...]` will be replaced accordingly.
 Currently, two generator types are supported: `uuid` and `password`:
 - `uuid` will generate a [RFC4122](https://datatracker.ietf.org/doc/html/rfc4122) UUIDv4 and allows the following arguments:
-  - `encoding=<base32|base64|base64_url|base64_raw|base64_raw_url>`: encoding to be applied to the generated uuid (note: use raw for no padding)
+  - `encoding=<base32|base64|base64_url|base64_raw|base64_raw_url|hex>`: encoding to be applied to the generated uuid (note: use raw for no padding)
 - `password` allows the following arguments:
   - `length=<1-99>`: length of the generated password (default 32)
   - `num_digits=<0-99>`: number of digits (0-9) in the generated password (default length/4)
   - `num_symbols=<0-99>`: number of symbols in the generated pasasword (default length/4)
   - `symbols=<chars>`: symbols (i.e. non-alphanumerics) to be used in the generated password (default: `~!@#$%^&*()_+-={}|:<>?,./`)
-  - `encoding=<base32|base64|base64_url|base64_raw|base64_raw_url>`: encoding to be applied to the generated password (note: the actual length will be larger than specified by length then).
+  - `encoding=<base32|base64|base64_url|base64_raw|base64_raw_url|hex>`: encoding to be applied to the generated password (note: the actual length will be larger than specified by length then).
 
 As a short form it is possible to just specify `%generate` as secret value, in which case a (32 character) password will be generated.
 

--- a/internal/webhook/mutator.go
+++ b/internal/webhook/mutator.go
@@ -8,6 +8,7 @@ package webhook
 import (
 	"encoding/base32"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -161,6 +162,8 @@ func encode(encoding string, value []byte) (string, error) {
 		encodedValue = base64.RawStdEncoding.EncodeToString(value)
 	case "base64_raw_url":
 		encodedValue = base64.RawURLEncoding.EncodeToString(value)
+	case "hex":
+		encodedValue = hex.EncodeToString(value)
 	default:
 		err = fmt.Errorf("unsupported encoding %s", encoding)
 	}

--- a/internal/webhook/mutator_test.go
+++ b/internal/webhook/mutator_test.go
@@ -8,6 +8,7 @@ package webhook
 import (
 	"encoding/base32"
 	"encoding/base64"
+	"encoding/hex"
 	"regexp"
 	"testing"
 
@@ -226,6 +227,16 @@ func TestGenerateValue(t *testing.T) {
 		t.Errorf("generateValue: got invalid password (invalid base64 encoding): %s", v)
 	}
 
+	// password with hex encoding
+	v, err = generateValue("password:length=5;num_digits=0;num_symbols=5;symbols=_;encoding=hex")
+	if err != nil {
+		t.Fatalf("generateValue: got errror: %s", err)
+	}
+	if v != "5f5f5f5f5f" {
+		// 5f5f5f5f5f is hex of _____
+		t.Errorf("generateValue: got invalid password (invalid hex encoding): %s", v)
+	}
+
 	// uuid
 	v, err = generateValue("uuid")
 	if err != nil {
@@ -282,6 +293,16 @@ func TestGenerateValue(t *testing.T) {
 		t.Fatalf("generateValue: got errror: %s", err)
 	}
 	decodedUuidBytes, _ = base64.RawURLEncoding.DecodeString(v)
+	if _, err := uuid.FromBytes(decodedUuidBytes); err != nil {
+		t.Errorf("generateValue: got invalid uuid; error: %s", err)
+	}
+
+	// uuid encoding hex
+	v, err = generateValue("uuid:encoding=hex")
+	if err != nil {
+		t.Fatalf("generateValue: got errror: %s", err)
+	}
+	decodedUuidBytes, _ = hex.DecodeString(v)
 	if _, err := uuid.FromBytes(decodedUuidBytes); err != nil {
 		t.Errorf("generateValue: got invalid uuid; error: %s", err)
 	}

--- a/internal/webhook/suite_test.go
+++ b/internal/webhook/suite_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"encoding/base32"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"maps"
 	"net"
@@ -214,6 +215,16 @@ var _ = Describe("Create secrets", func() {
 		Expect(secret.Data).To(HaveKey("base64RawUrlPasswordKey"))
 		Expect(secret.Data["base64RawUrlPasswordKey"]).NotTo(BeEmpty())
 		_, err = base64.RawURLEncoding.DecodeString(string(secret.Data["base64RawUrlPasswordKey"]))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(secret.Data).To(HaveKey("hexUuidKey"))
+		Expect(secret.Data["hexUuidKey"]).NotTo(BeEmpty())
+		_, err = hex.DecodeString(string(secret.Data["hexUuidKey"]))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(secret.Data).To(HaveKey("hexPasswordKey"))
+		Expect(secret.Data["hexPasswordKey"]).NotTo(BeEmpty())
+		_, err = hex.DecodeString(string(secret.Data["hexPasswordKey"]))
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
## Description

This PR implements hex encoding support for both password and UUID generators, addressing the need for hexadecimal-encoded secrets in various applications and configuration systems.

Closes #185 

## Usage Examples

After this change, users can generate hex-encoded secrets:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-secret
  labels:
    secret-generator.cs.sap.com/enabled: "true"
stringData:
  hex-password: "%generate:password:length=16;encoding=hex"
  hex-uuid: "%generate:uuid:encoding=hex"
```
